### PR TITLE
Update coreaudio.cc to compile on node v4 (mac)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,3 +70,4 @@ AirTunes.prototype.end = function() {
 };
 
 module.exports = new AirTunes();
+module.exports.AirTunes = AirTunes;

--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -49,11 +49,11 @@ Client.prototype.startHandshake = function(udpServers, host, port) {
   var self = this;
 
   this.startTimeout();
-  
+
   this.controlPort = udpServers.control.port;
   this.timingPort  = udpServers.timing.port;
-  
-  
+
+
   this.socket = net.connect(port, host, function() {
     self.clearTimeout();
     self.sendNextRequest();
@@ -68,16 +68,18 @@ Client.prototype.startHandshake = function(udpServers, host, port) {
      * I assume that all responses have empty bodies.
      */
     data = data.toString();
-    var endIndex = data.indexOf('\r\n\r\n');
 
-    if(endIndex < 0) {
-      blob += data;
+    blob += data;
+    var endIndex = blob.indexOf('\r\n\r\n');
+
+    if (endIndex < 0) {
       return;
     }
 
-    endIndex += 4; // the end of \r\n\r\n
+    endIndex += 4;
 
-    blob += data.substring(0, endIndex);
+    blob = blob.substring(0, endIndex);
+
     self.processData(blob);
 
     blob = data.substring(endIndex);

--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -231,7 +231,7 @@ function parseResponse(blob) {
 
   var headers = {};
   lines.slice(1).forEach(function(line) {
-    var res = /([^:]+): ?(.*)/.exec(line);
+    var res = /([^:]+):\s*(.*)/.exec(line);
 
     if(!res)
       return;

--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -231,7 +231,7 @@ function parseResponse(blob) {
 
   var headers = {};
   lines.slice(1).forEach(function(line) {
-    var res = /([^:]+): (.*)/.exec(line);
+    var res = /([^:]+): ?(.*)/.exec(line);
 
     if(!res)
       return;


### PR DESCRIPTION
Breaking API changes in Node 0.12 require updates to coreaudio.cc, which is only necessary for Mac.

Please note, my C++ knowledge is elementary at best, and even after working on this, I don't really understand the HandleScope/Isolate facilities in play here.

However, it compiles and the examples work!
- OSX Yosemite (10.10.5)
- Node v4.2.4 (does not compile on v0.12).
